### PR TITLE
`activeTab` permission instead of `Tabs` in manifest.json.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,6 @@
   },
   "permissions": [
     "storage",
-    "tabs"
+    "activeTab"
   ]
 }


### PR DESCRIPTION
The only needed access is to the currently active tab in the user's browser. Tabs permission is wider for the extension's purpose.